### PR TITLE
patch for dmSIGINT_end

### DIFF
--- a/GameData/DMagicOrbitalScience/OversizeScience/SIGINT_End.cfg
+++ b/GameData/DMagicOrbitalScience/OversizeScience/SIGINT_End.cfg
@@ -1,6 +1,6 @@
 PART
 {
-name = dmSIGINT.End
+name = dmSIGINT_End
 module = Part
 author = DMagic
 

--- a/GameData/DMagicOrbitalScience/Resources/DMContracts.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMContracts.cfg
@@ -132,7 +132,7 @@ DMContracts
 		Exceptional_Experiment_Title = Recon Scan
 		Use_Vessel_Waypoints = true
 		Trivial_Parts = dmReconSmall
-		Significant_Parts = dmSIGINT,dmSIGINT.Small,dmSIGINT.End
+		Significant_Parts = dmSIGINT,dmSIGINT.Small,dmSIGINT_End
 		Exceptional_Parts = dmReconLarge
 		Expire
 		{

--- a/GameData/DMagicOrbitalScience/Resources/DMagicCommunityTechTree.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMagicCommunityTechTree.cfg
@@ -127,7 +127,7 @@
 	@cost = 20000
 }
 
-@PART[dmSIGINT.End]:FOR[DMagic]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@PART[dmSIGINT_End]:FOR[DMagic]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
     @TechRequired = advUnmanned
 	@entryCost = 25000

--- a/GameData/DMagicOrbitalScience/Resources/DMagicTweakScale.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMagicTweakScale.cfg
@@ -100,7 +100,7 @@ TWEAKSCALEEXPONENTS
 	}
 }
 
-@PART[dmSIGINT.End]:FOR[DMagic]:NEEDS[Scale]
+@PART[dmSIGINT_End]:FOR[DMagic]:NEEDS[Scale]
 {
 	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
 	%MODULE[TweakScale]


### PR DESCRIPTION
[LOG 00:20:32.509] [TweakScale] INFO: NULL ConfigNode for DMagicOrbitalScience/OversizeScience/SIGINT_End/dmSIGINT.End (unholy characters on the name?). Trying partConfig instead!

Fixes TweakScale issue with unholy characters (spaces).

Change impacts the following **known** mods:

**002_CommunityPartsTitles** (\GameData\002_CommunityPartsTitles\Localization\patch_dmagic_ker.cfg)
**Kerbalism** (\GameData\KerbalismConfig\Support\DMagicOrbitalScience_Science.cfg)
**ProbesBeforeCrew** (\GameData\ProbesBeforeCrew\Mod Support\ZsDMagicPatch.cfg)
**SignalDelay** (\GameData\SignalDelay\Patches\DMOrbitalScience.cfg)
**UnKerballedStart** (\GameData\UnKerballedStart\Mod Support\DMagicOrbitalScience.cfg)

