### PR TITLE
patch for dmSIGINT_small

### DIFF
--- a/GameData/DMagicOrbitalScience/OversizeScience/SIGINT_Small.cfg
+++ b/GameData/DMagicOrbitalScience/OversizeScience/SIGINT_Small.cfg
@@ -1,6 +1,6 @@
 PART
 {
-name = dmSIGINT.Small
+name = dmSIGINT_Small
 module = Part
 author = DMagic
 

--- a/GameData/DMagicOrbitalScience/Resources/DMContracts.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMContracts.cfg
@@ -132,7 +132,7 @@ DMContracts
 		Exceptional_Experiment_Title = Recon Scan
 		Use_Vessel_Waypoints = true
 		Trivial_Parts = dmReconSmall
-		Significant_Parts = dmSIGINT,dmSIGINT.Small,dmSIGINT_End
+		Significant_Parts = dmSIGINT,dmSIGINT_Small,dmSIGINT_End
 		Exceptional_Parts = dmReconLarge
 		Expire
 		{
@@ -365,7 +365,7 @@ DMContracts
 		experimentID = dmSIGINT
 		xmitDataScalar = 1
 		type = 1
-		part = dmSIGINT.Small
+		part = dmSIGINT_Small
 		agent = DMagic
 	}
 }

--- a/GameData/DMagicOrbitalScience/Resources/DMagicCommunityTechTree.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMagicCommunityTechTree.cfg
@@ -134,7 +134,7 @@
 	@cost = 20000
 }
 
-@PART[dmSIGINT.Small]:FOR[DMagic]:NEEDS[CommunityTechTree,!RP-0,!SETI]
+@PART[dmSIGINT_Small]:FOR[DMagic]:NEEDS[CommunityTechTree,!RP-0,!SETI]
 {
 	@entryCost = 20000
 	@cost = 14000

--- a/GameData/DMagicOrbitalScience/Resources/DMagicTweakScale.cfg
+++ b/GameData/DMagicOrbitalScience/Resources/DMagicTweakScale.cfg
@@ -113,7 +113,7 @@ TWEAKSCALEEXPONENTS
 	}
 }
 
-@PART[dmSIGINT.Small]:FOR[DMagic]:NEEDS[Scale]
+@PART[dmSIGINT_Small]:FOR[DMagic]:NEEDS[Scale]
 {
 	#@TWEAKSCALEBEHAVIOR[Science]/MODULE[TweakScale] { }
 	%MODULE[TweakScale]


### PR DESCRIPTION
[LOG 00:20:32.509] [TweakScale] INFO: NULL ConfigNode for DMagicOrbitalScience/OversizeScience/SIGINT_End/dmSIGINT.End (unholy characters on the name?). Trying partConfig instead!

Fixes TweakScale issue with unholy characters (spaces).

Change impacts the following known mods:

**002_CommunityPartsTitles** (\GameData\002_CommunityPartsTitles\Localization\patch_dmagic_ker.cfg)
**Bluedog_DB** (\GameData\Bluedog_DB\Compatibility\Tweakscale\DMagic_TweakScale.cfg)
**Kerbalism** (\GameData\KerbalismConfig\Support\DMagicOrbitalScience_Science.cfg)
**ProbesBeforeCrew** (\GameData\ProbesBeforeCrew\Mod Support\ZsDMagicPatch.cfg)
**SignalDelay** (\GameData\SignalDelay\Patches\DMOrbitalScience.cfg)
**UnKerballedStart** (\GameData\UnKerballedStart\Mod Support\DMagicOrbitalScience.cfg)